### PR TITLE
temporary car detail fix

### DIFF
--- a/car_auction_service/car_auctions/views.py
+++ b/car_auction_service/car_auctions/views.py
@@ -37,7 +37,7 @@ def cars_list(request):
     context = {'car_adverts': car_adverts_filter}
     return render(request, 'car_auctions/cars_main.html', context)
 
-
+@login_required(login_url='/users/accounts/login')
 def car_advert_detail(request, pk):
     """
     Display an individual :model: 'car_auctions.CarAdvert'.


### PR DESCRIPTION
Temporary fix for car detail functionallity. A not logged in user cannot access the car detail view. The changed view is only for logged in users. To fix this issue car history/ observed cars should also be available to not logged in users through django session, cookies or other solutions.
